### PR TITLE
Make the dev server and his websocket use SSL by using the same cert files as app server.

### DIFF
--- a/dev/dist/devServer_unstable/index.js
+++ b/dev/dist/devServer_unstable/index.js
@@ -178,7 +178,8 @@ let serve = async (initialConfig, options) => {
       env: {
         NODE_ENV: "development",
         PATH: `${bin}:${process.env.PATH}`,
-        REMIX_DEV_HTTP_ORIGIN: stringifyOrigin(httpOrigin)
+        REMIX_DEV_HTTP_ORIGIN: stringifyOrigin(httpOrigin),
+        FORCE_COLOR: '1'
       }
     });
     if (newAppServer.stdin) process.stdin.pipe(newAppServer.stdin, {

--- a/dev/dist/devServer_unstable/socket.js
+++ b/dev/dist/devServer_unstable/socket.js
@@ -19,9 +19,20 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
 var WebSocket__default = /*#__PURE__*/_interopDefaultLegacy(WebSocket);
 
 let serve = options => {
+  //////////////////////////////////////////////////////////////////////////////
+  // SN EDIT
+  // let wss = new WebSocket__default["default"].Server({
+  //   port: options.port
+  // });
+
+  // if we have a server, use that, otherwise use port
   let wss = new WebSocket__default["default"].Server({
-    port: options.port
+    ...(options.server
+      ? { server: options.server }
+      : { port: options.port }),
   });
+  // SN EDIT END
+  //////////////////////////////////////////////////////////////////////////////
   let broadcast = message => {
     wss.clients.forEach(client => {
       if (client.readyState === WebSocket__default["default"].OPEN) {


### PR DESCRIPTION
- dev express server now uses an https.createServer with local certificate files
- dev server websocket server now uses the https server instead of using a port
- websocket port must be set to dev server port, done via remix.config.js